### PR TITLE
[DATA-1019] Allow limit config on MercuryTechnologies/pipelinewise-tap-postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Full list of options in `config.json`:
 | break_at_end_lsn                    | Boolean | No         | Stop running the tap if the newly received lsn is after the max lsn that was detected when the tap started. (Default: true) |
 | max_run_seconds                     | Integer | No         | Stop running the tap after certain number of seconds. (Default: 43200) |
 | debug_lsn                           | String  | No         | If set to `"true"` then add `_sdc_lsn` property to the singer messages to debug postgres LSN position in the WAL stream. (Default: None) |
+| limit                               | Integer | No         | Adds a limit to INCREMENTAL queries to limit the number of records returns per run. (Default: None) |
 
 
 ### Run the tap in Discovery Mode

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -390,6 +390,8 @@ def main_impl():
     Main method
     """
     args = parse_args(REQUIRED_CONFIG_KEYS)
+
+    limit = args.config.get('limit')
     conn_config = {
         # Required config keys
         'host': args.config['host'],
@@ -404,7 +406,8 @@ def main_impl():
         'debug_lsn': args.config.get('debug_lsn') == 'true',
         'max_run_seconds': args.config.get('max_run_seconds', 43200),
         'break_at_end_lsn': args.config.get('break_at_end_lsn', True),
-        'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0))
+        'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0)),
+        'limit': int(limit) if limit else None
     }
 
     if args.config.get('ssl') == 'true':

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -80,26 +80,14 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor, name='pipelinewise') as cur:
                 cur.itersize = post_db.CURSOR_ITER_SIZE
                 LOGGER.info("Beginning new incremental replication sync %s", stream_version)
-                if replication_key_value:
-                    select_sql = """SELECT {}
-                                    FROM {}
-                                    WHERE {} >= '{}'::{}
-                                    ORDER BY {} ASC""".format(','.join(escaped_columns),
-                                                              post_db.fully_qualified_table_name(schema_name,
-                                                                                                 stream['table_name']),
-                                                              post_db.prepare_columns_sql(replication_key),
-                                                              replication_key_value,
-                                                              replication_key_sql_datatype,
-                                                              post_db.prepare_columns_sql(replication_key))
-                else:
-                    #if not replication_key_value
-                    select_sql = """SELECT {}
-                                    FROM {}
-                                    ORDER BY {} ASC""".format(','.join(escaped_columns),
-                                                              post_db.fully_qualified_table_name(schema_name,
-                                                                                                 stream['table_name']),
-                                                              post_db.prepare_columns_sql(replication_key))
-
+                select_sql = _get_select_sql({"escaped_columns": escaped_columns,
+                                              "replication_key": replication_key,
+                                              "replication_key_sql_datatype": replication_key_sql_datatype,
+                                              "replication_key_value": replication_key_value,
+                                              "schema_name": schema_name,
+                                              "table_name": stream['table_name'],
+                                              "limit": conn_info['limit']
+                                              })
                 LOGGER.info('select statement: %s with itersize %s', select_sql, cur.itersize)
                 cur.execute(select_sql)
 
@@ -124,10 +112,33 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
                                                       'replication_key_value',
                                                       record_message.record[replication_key])
 
-
                     if rows_saved % UPDATE_BOOKMARK_PERIOD == 0:
                         singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
                     counter.increment()
 
     return state
+
+
+def _get_select_sql(params):
+    escaped_columns = params['escaped_columns']
+    replication_key = post_db.prepare_columns_sql(params['replication_key'])
+    replication_key_sql_datatype = params['replication_key_sql_datatype']
+    replication_key_value = params['replication_key_value']
+    schema_name = params['schema_name']
+    table_name = params['table_name']
+
+    limit_statement = f'LIMIT {params["limit"]}' if params["limit"] else ''
+    where_statement = f"WHERE {replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}" \
+        if replication_key_value else ""
+
+    select_sql = f"""
+    SELECT {','.join(escaped_columns)}
+    FROM (
+        SELECT *
+        FROM {post_db.fully_qualified_table_name(schema_name, table_name)} 
+        {where_statement}
+        ORDER BY {replication_key} ASC {limit_statement}
+    ) pg_speedup_trick;"""
+
+    return select_sql

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -139,6 +139,6 @@ def _get_select_sql(params):
         FROM {post_db.fully_qualified_table_name(schema_name, table_name)} 
         {where_statement}
         ORDER BY {replication_key} ASC {limit_statement}
-    ) pg_speedup_trick;"""
+    );"""
 
     return select_sql

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -139,6 +139,6 @@ def _get_select_sql(params):
         FROM {post_db.fully_qualified_table_name(schema_name, table_name)} 
         {where_statement}
         ORDER BY {replication_key} ASC {limit_statement}
-    );"""
+    ) pg_speedup_trick;"""
 
     return select_sql


### PR DESCRIPTION
Linear: https://linear.app/mercury/issue/DATA-1019/limit-the-size-of-meltano-data-pulls-with-limit-postgres-tap-config

**Context**

The latest version of pipelinewise-tap-postgres allows you to configure a setting on the tap called `limit`. This appends a `LIMIT N` clause to all the queries your extractor runs against Postgres. We think this will be an effective short-term solution to our need to throttle long-running queries Meltano starts against the read replica, which block autovacuum. 

**Description**

This PR is a cherry-pick of the commit which adds the `LIMIT` setting to the transferwise version of this repository. 
https://github.com/transferwise/pipelinewise-tap-postgres/pull/211

The biggest change in this PR is in tap_postgres/sync_strategies/incremental.py, where the logic that builds the SQL statement has been moved into its own function, `_get_select_sql`. 

[The diff in our repository is extremely similar to the diff in the original transferwise PR.](https://github.com/transferwise/pipelinewise-tap-postgres/pull/211/files#diff-f45be604034c53a31927c986aeb8b360cae40502b086afb6539a4fe2c4b8b0c3L130) 

However, there's a couple of differences here to be aware of: 
* _String building._ the transferwise variant uses f-strings while the Mercury variant use the `.format` method.
* _pg_speedup_trick_. the transferwise variant wraps the incremental query in a `SELECT *` subquery to improve performance on date time indexes. The explanation of this change is here: https://github.com/transferwise/pipelinewise-tap-postgres/pull/189. It seems to be a neutral change for our use case and the team is comfortable including it. 

**Testing**
- [ ] Using the new SQL generation logic, hand-edit some values in and run the statement manually against MWB.
- [ ] Would love other ideas about testing!

**Deployment**
I assume this will be deployed and packaged with Meltano via nix, but I'm not sure when or how that happens. https://github.com/MercuryTechnologies/infrastructure/tree/d11a1ce5d9bdcd4c5d8b164fe151326bf5ec9ca8/roles/overlays/elt
